### PR TITLE
Fix: Support parsing Unicode characters enclosed in brackets

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -282,7 +282,13 @@ impl<'a> Parser<'a> {
                     escapes += 1;
                     let next_c = self.next()?;
                     if *next_c == b'u' {
-                        self.step_by(UNICODE_LEN + 1);
+                        self.step();
+                        let next_c = self.next()?;
+                        if *next_c == b'{' {
+                            self.step_by(UNICODE_LEN + 2);
+                        } else {
+                            self.step_by(UNICODE_LEN);
+                        }
                     } else {
                         self.step();
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -61,8 +61,15 @@ pub fn parse_escaped_string<'a>(
         b't' => str_buf.push(TT),
         b'u' => {
             let mut numbers = vec![0; UNICODE_LEN];
-            data.read_exact(numbers.as_mut_slice())?;
-            *idx += 4;
+            if data[0] == b'{' {
+                data = &data[1..];
+                data.read_exact(numbers.as_mut_slice())?;
+                data = &data[1..];
+                *idx += 6;
+            } else {
+                data.read_exact(numbers.as_mut_slice())?;
+                *idx += 4;
+            }
             let hex = decode_hex_escape(numbers.clone(), idx)?;
 
             let c = match hex {
@@ -88,8 +95,15 @@ pub fn parse_escaped_string<'a>(
                         return Ok(data);
                     }
                     let mut lower_numbers = vec![0; UNICODE_LEN];
-                    data.read_exact(lower_numbers.as_mut_slice())?;
-                    *idx += 4;
+                    if data[0] == b'{' {
+                        data = &data[1..];
+                        data.read_exact(lower_numbers.as_mut_slice())?;
+                        data = &data[1..];
+                        *idx += 6;
+                    } else {
+                        data.read_exact(lower_numbers.as_mut_slice())?;
+                        *idx += 4;
+                    }
                     let n2 = decode_hex_escape(lower_numbers.clone(), idx)?;
                     if !(0xDC00..=0xDFFF).contains(&n2) {
                         encode_invalid_unicode(numbers, str_buf);

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,6 +64,9 @@ pub fn parse_escaped_string<'a>(
             if data[0] == b'{' {
                 data = &data[1..];
                 data.read_exact(numbers.as_mut_slice())?;
+                if data[0] != b'}' {
+                    return Err(Error::Syntax(ParseErrorCode::UnexpectedEndOfHexEscape, *idx));
+                }
                 data = &data[1..];
                 *idx += 6;
             } else {
@@ -98,6 +101,9 @@ pub fn parse_escaped_string<'a>(
                     if data[0] == b'{' {
                         data = &data[1..];
                         data.read_exact(lower_numbers.as_mut_slice())?;
+                        if data[0] != b'}' {
+                            return Err(Error::Syntax(ParseErrorCode::UnexpectedEndOfHexEscape, *idx));
+                        }
                         data = &data[1..];
                         *idx += 6;
                     } else {

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -310,6 +310,10 @@ fn test_parse_string() {
             r#""\"ab\"\uD803\uDC0B测试""#,
             Value::String(Cow::from("\"ab\"𐰋测试")),
         ),
+        (
+            r#""⚠\u{fe0f}""#,
+            Value::String(Cow::from("⚠\u{fe0f}")),
+        ),
     ]);
 }
 


### PR DESCRIPTION
Support parsing Unicode characters enclosed in brackets, for example: `"\u{fe0f}"`.