### PR TITLE
Feat: Add function convert_to_comparable, rand_value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ byteorder = "1.4.3"
 fast-float = "0.2.0"
 nom = "7.1.3"
 ordered-float = { version = "3.6.0", default-features = false }
+rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = { version = "1.0.95", default-features = false, features = [
   "preserve_order",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -59,3 +59,13 @@ pub(crate) const FF: char = '\x0C'; // \f Formfeed Page Break
 pub(crate) const NN: char = '\x0A'; // \n Newline
 pub(crate) const RR: char = '\x0D'; // \r Carriage Return
 pub(crate) const TT: char = '\x09'; // \t Horizontal Tab
+
+// JSONB value compare level
+pub(crate) const NULL_LEVEL: u8 = 7;
+pub(crate) const ARRAY_LEVEL: u8 = 6;
+pub(crate) const OBJECT_LEVEL: u8 = 5;
+pub(crate) const STRING_LEVEL: u8 = 4;
+pub(crate) const NUMBER_LEVEL: u8 = 3;
+pub(crate) const TRUE_LEVEL: u8 = 2;
+pub(crate) const FALSE_LEVEL: u8 = 1;
+pub(crate) const INVALID_LEVEL: u8 = 0;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -273,9 +273,6 @@ impl<'a> Parser<'a> {
         let mut escapes = 0;
         loop {
             let c = self.next()?;
-            if c.is_ascii_control() {
-                return Err(self.error(ParseErrorCode::ControlCharacterWhileParsingString));
-            }
             match c {
                 b'\\' => {
                     self.step();

--- a/tests/it/parser.rs
+++ b/tests/it/parser.rs
@@ -251,14 +251,6 @@ fn test_parse_string() {
         ("\"", "EOF while parsing a value, pos 1"),
         ("\"lol", "EOF while parsing a value, pos 4"),
         ("\"lol\"a", "trailing characters, pos 6"),
-        (
-            "\"\n\"",
-            "control character (\\u0000-\\u001F) found while parsing a string, pos 1",
-        ),
-        (
-            "\"\x1F\"",
-            "control character (\\u0000-\\u001F) found while parsing a string, pos 1",
-        ),
     ]);
 
     test_parse_ok(vec![


### PR DESCRIPTION
- `convert_to_comparable` convert JSONB value to comparable format.
- `rand_value` generate a random JSONB value.
- Modify the compare rule for Object types, the larger the key, the larger the Object.
- Parse string allow control characters.

the comparable format is used by row sort in https://github.com/datafuselabs/databend/pull/11765