### PR TITLE
Feat: improve json path selector using less memory

### DIFF
--- a/src/jsonpath/selector.rs
+++ b/src/jsonpath/selector.rs
@@ -33,10 +33,13 @@ use nom::{
     bytes::complete::take, combinator::map, multi::count, number::complete::be_u32, IResult,
 };
 
-#[derive(Debug)]
-enum Item<'a> {
-    Container(&'a [u8]),
-    Scalar(Vec<u8>),
+/// The position of jsonb value.
+#[derive(Clone, Debug)]
+enum Position {
+    /// The offset and length of jsonb container value.
+    Container((usize, usize)),
+    /// The type, offset and length of jsonb scalar value.
+    Scalar((u32, usize, usize)),
 }
 
 #[derive(Debug)]
@@ -45,19 +48,33 @@ enum ExprValue<'a> {
     Value(Box<PathValue<'a>>),
 }
 
+/// Mode determines the different forms of the return value.
+#[derive(Clone, PartialEq, Debug)]
+pub enum Mode {
+    /// Only return the first jsonb value.
+    First,
+    /// Return all values as a jsonb Array.
+    Array,
+    /// Return each jsonb value separately.
+    All,
+    /// If there are multiple values, return a jsonb Array,
+    /// if there is only one value, return the jsonb value directly.
+    Mixed,
+}
+
 pub struct Selector<'a> {
     json_path: JsonPath<'a>,
+    mode: Mode,
 }
 
 impl<'a> Selector<'a> {
-    pub fn new(json_path: JsonPath<'a>) -> Self {
-        Self { json_path }
+    pub fn new(json_path: JsonPath<'a>, mode: Mode) -> Self {
+        Self { json_path, mode }
     }
 
-    pub fn select(&'a self, value: &'a [u8]) -> Vec<Vec<u8>> {
-        let root = value;
-        let mut items = VecDeque::new();
-        items.push_back(Item::Container(value));
+    pub fn select(&'a self, root: &'a [u8], data: &mut Vec<u8>, offsets: &mut Vec<u64>) {
+        let mut poses = VecDeque::new();
+        poses.push_back(Position::Container((0, root.len())));
 
         for path in self.json_path.paths.iter() {
             match path {
@@ -66,32 +83,26 @@ impl<'a> Selector<'a> {
                 }
                 &Path::Current => unreachable!(),
                 Path::FilterExpr(expr) => {
-                    let mut tmp_items = Vec::with_capacity(items.len());
-                    while let Some(item) = items.pop_front() {
-                        let current = match item {
-                            Item::Container(val) => val,
-                            Item::Scalar(ref val) => val.as_slice(),
-                        };
-                        if self.filter_expr(root, current, expr) {
-                            tmp_items.push(item);
+                    let len = poses.len();
+                    for _ in 0..len {
+                        let pos = poses.pop_front().unwrap();
+                        if self.filter_expr(root, &pos, expr) {
+                            poses.push_back(pos);
                         }
-                    }
-                    while let Some(item) = tmp_items.pop() {
-                        items.push_front(item);
                     }
                 }
                 _ => {
-                    let len = items.len();
+                    let len = poses.len();
                     for _ in 0..len {
-                        let item = items.pop_front().unwrap();
-                        match item {
-                            Item::Container(current) => {
-                                self.select_path(current, path, &mut items);
+                        let pos = poses.pop_front().unwrap();
+                        match pos {
+                            Position::Container((offset, length)) => {
+                                self.select_path(root, offset, length, path, &mut poses);
                             }
-                            Item::Scalar(_) => {
+                            Position::Scalar(_) => {
                                 // In lax mode, bracket wildcard allow Scalar value.
                                 if path == &Path::BracketWildcard {
-                                    items.push_back(item);
+                                    poses.push_back(pos);
                                 }
                             }
                         }
@@ -99,105 +110,127 @@ impl<'a> Selector<'a> {
                 }
             }
         }
-        let mut values = Vec::new();
-        while let Some(item) = items.pop_front() {
-            match item {
-                Item::Container(val) => {
-                    values.push(val.to_vec());
-                }
-                Item::Scalar(val) => {
-                    values.push(val);
+
+        match self.mode {
+            Mode::All => Self::build_values(root, &mut poses, data, offsets),
+            Mode::First => {
+                poses.truncate(1);
+                Self::build_values(root, &mut poses, data, offsets)
+            }
+            Mode::Array => Self::build_scalar_array(root, &mut poses, data, offsets),
+            Mode::Mixed => {
+                if poses.len() > 1 {
+                    Self::build_scalar_array(root, &mut poses, data, offsets)
+                } else {
+                    Self::build_values(root, &mut poses, data, offsets)
                 }
             }
         }
-        values
     }
 
-    fn select_path(&'a self, current: &'a [u8], path: &Path<'a>, items: &mut VecDeque<Item<'a>>) {
+    fn select_path(
+        &'a self,
+        root: &'a [u8],
+        offset: usize,
+        length: usize,
+        path: &Path<'a>,
+        poses: &mut VecDeque<Position>,
+    ) {
         match path {
             Path::DotWildcard => {
-                self.select_object_values(current, items);
+                self.select_object_values(root, offset, poses);
             }
             Path::BracketWildcard => {
-                self.select_array_values(current, items);
+                self.select_array_values(root, offset, length, poses);
             }
             Path::ColonField(name) | Path::DotField(name) | Path::ObjectField(name) => {
-                self.select_by_name(current, name, items);
+                self.select_by_name(root, offset, name, poses);
             }
             Path::ArrayIndices(indices) => {
-                self.select_by_indices(current, indices, items);
+                self.select_by_indices(root, offset, indices, poses);
             }
             _ => unreachable!(),
         }
     }
 
     // select all values in an Object.
-    fn select_object_values(&'a self, current: &'a [u8], items: &mut VecDeque<Item<'a>>) {
-        let (rest, (ty, length)) = decode_header(current).unwrap();
+    fn select_object_values(
+        &'a self,
+        root: &'a [u8],
+        root_offset: usize,
+        poses: &mut VecDeque<Position>,
+    ) {
+        let (rest, (ty, length)) = decode_header(&root[root_offset..]).unwrap();
         if ty != OBJECT_CONTAINER_TAG || length == 0 {
             return;
         }
         let (rest, key_jentries) = decode_jentries(rest, length).unwrap();
-        let (rest, val_jentries) = decode_jentries(rest, length).unwrap();
-        let mut offset = 0;
+        let (_, val_jentries) = decode_jentries(rest, length).unwrap();
+        let mut offset = root_offset + 4 + length * 8;
         for (_, length) in key_jentries.iter() {
             offset += length;
         }
-        let rest = &rest[offset..];
-        offset = 0;
         for (jty, jlength) in val_jentries.iter() {
-            let val = &rest[offset..offset + jlength];
-            let item = if *jty == CONTAINER_TAG {
-                Item::Container(val)
+            let pos = if *jty == CONTAINER_TAG {
+                Position::Container((offset, *jlength))
             } else {
-                let buf = Self::build_scalar_buf(*jty, *jlength, val);
-                Item::Scalar(buf)
+                Position::Scalar((*jty, offset, *jlength))
             };
-            items.push_back(item);
+            poses.push_back(pos);
             offset += jlength;
         }
     }
 
     // select all values in an Array.
-    fn select_array_values(&'a self, current: &'a [u8], items: &mut VecDeque<Item<'a>>) {
-        let (rest, (ty, length)) = decode_header(current).unwrap();
+    fn select_array_values(
+        &'a self,
+        root: &'a [u8],
+        root_offset: usize,
+        root_length: usize,
+        poses: &mut VecDeque<Position>,
+    ) {
+        let (rest, (ty, length)) = decode_header(&root[root_offset..]).unwrap();
         if ty != ARRAY_CONTAINER_TAG {
             // In lax mode, bracket wildcard allow Scalar value.
-            items.push_back(Item::Container(current));
+            poses.push_back(Position::Container((root_offset, root_length)));
             return;
         }
-        let (rest, val_jentries) = decode_jentries(rest, length).unwrap();
-        let mut offset = 0;
+        let (_, val_jentries) = decode_jentries(rest, length).unwrap();
+        let mut offset = root_offset + 4 + length * 4;
         for (jty, jlength) in val_jentries.iter() {
-            let val = &rest[offset..offset + jlength];
-            let item = if *jty == CONTAINER_TAG {
-                Item::Container(val)
+            let pos = if *jty == CONTAINER_TAG {
+                Position::Container((offset, *jlength))
             } else {
-                let buf = Self::build_scalar_buf(*jty, *jlength, val);
-                Item::Scalar(buf)
+                Position::Scalar((*jty, offset, *jlength))
             };
-            items.push_back(item);
+            poses.push_back(pos);
             offset += jlength;
         }
     }
 
     // select value in an Object by key name.
-    fn select_by_name(&'a self, current: &'a [u8], name: &str, items: &mut VecDeque<Item<'a>>) {
-        let (rest, (ty, length)) = decode_header(current).unwrap();
+    fn select_by_name(
+        &'a self,
+        root: &'a [u8],
+        root_offset: usize,
+        name: &str,
+        poses: &mut VecDeque<Position>,
+    ) {
+        let (rest, (ty, length)) = decode_header(&root[root_offset..]).unwrap();
         if ty != OBJECT_CONTAINER_TAG || length == 0 {
             return;
         }
         let (rest, key_jentries) = decode_jentries(rest, length).unwrap();
-        let (rest, val_jentries) = decode_jentries(rest, length).unwrap();
+        let (_, val_jentries) = decode_jentries(rest, length).unwrap();
         let mut idx = 0;
-        let mut offset = 0;
+        let mut offset = root_offset + 4 + length * 8;
         let mut found = false;
         for (i, (_, jlength)) in key_jentries.iter().enumerate() {
             if name.len() != *jlength || found {
                 offset += jlength;
                 continue;
             }
-            let (_, key) = decode_string(&rest[offset..], *jlength).unwrap();
+            let (_, key) = decode_string(&root[offset..], *jlength).unwrap();
             if name == unsafe { std::str::from_utf8_unchecked(key) } {
                 found = true;
                 idx = i;
@@ -207,21 +240,17 @@ impl<'a> Selector<'a> {
         if !found {
             return;
         }
-        let rest = &rest[offset..];
-        offset = 0;
         for (i, (jty, jlength)) in val_jentries.iter().enumerate() {
             if i != idx {
                 offset += jlength;
                 continue;
             }
-            let val = &rest[offset..offset + jlength];
-            let item = if *jty == CONTAINER_TAG {
-                Item::Container(val)
+            let pos = if *jty == CONTAINER_TAG {
+                Position::Container((offset, *jlength))
             } else {
-                let buf = Self::build_scalar_buf(*jty, *jlength, val);
-                Item::Scalar(buf)
+                Position::Scalar((*jty, offset, *jlength))
             };
-            items.push_back(item);
+            poses.push_back(pos);
             break;
         }
     }
@@ -229,11 +258,12 @@ impl<'a> Selector<'a> {
     // select values in an Array by indices.
     fn select_by_indices(
         &'a self,
-        current: &'a [u8],
+        root: &'a [u8],
+        root_offset: usize,
         indices: &Vec<ArrayIndex>,
-        items: &mut VecDeque<Item<'a>>,
+        poses: &mut VecDeque<Position>,
     ) {
-        let (rest, (ty, length)) = decode_header(current).unwrap();
+        let (rest, (ty, length)) = decode_header(&root[root_offset..]).unwrap();
         if ty != ARRAY_CONTAINER_TAG || length == 0 {
             return;
         }
@@ -255,8 +285,8 @@ impl<'a> Selector<'a> {
         if val_indices.is_empty() {
             return;
         }
-        let (rest, jentries) = decode_jentries(rest, length).unwrap();
-        let mut offset = 0;
+        let (_, jentries) = decode_jentries(rest, length).unwrap();
+        let mut offset = root_offset + 4 + length * 4;
         let mut offsets = Vec::with_capacity(jentries.len());
         for (_, jlength) in jentries.iter() {
             offsets.push(offset);
@@ -265,24 +295,71 @@ impl<'a> Selector<'a> {
         for i in val_indices {
             let offset = offsets[i];
             let (jty, jlength) = jentries[i];
-            let val = &rest[offset..offset + jlength];
-            let item = if jty == CONTAINER_TAG {
-                Item::Container(val)
+            let pos = if jty == CONTAINER_TAG {
+                Position::Container((offset, jlength))
             } else {
-                let buf = Self::build_scalar_buf(jty, jlength, val);
-                Item::Scalar(buf)
+                Position::Scalar((jty, offset, jlength))
             };
-            items.push_back(item);
+            poses.push_back(pos);
         }
     }
 
-    fn build_scalar_buf(jty: u32, jlength: usize, val: &'a [u8]) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(8 + jlength);
-        buf.write_u32::<BigEndian>(SCALAR_CONTAINER_TAG).unwrap();
-        let jentry = jty | jlength as u32;
-        buf.write_u32::<BigEndian>(jentry).unwrap();
-        buf.extend_from_slice(val);
-        buf
+    fn build_values(
+        root: &'a [u8],
+        poses: &mut VecDeque<Position>,
+        data: &mut Vec<u8>,
+        offsets: &mut Vec<u64>,
+    ) {
+        while let Some(pos) = poses.pop_front() {
+            match pos {
+                Position::Container((offset, length)) => {
+                    data.extend_from_slice(&root[offset..offset + length]);
+                }
+                Position::Scalar((ty, offset, length)) => {
+                    data.write_u32::<BigEndian>(SCALAR_CONTAINER_TAG).unwrap();
+                    let jentry = ty | length as u32;
+                    data.write_u32::<BigEndian>(jentry).unwrap();
+                    if length > 0 {
+                        data.extend_from_slice(&root[offset..offset + length]);
+                    }
+                }
+            }
+            offsets.push(data.len() as u64);
+        }
+    }
+
+    fn build_scalar_array(
+        root: &'a [u8],
+        poses: &mut VecDeque<Position>,
+        data: &mut Vec<u8>,
+        offsets: &mut Vec<u64>,
+    ) {
+        let len = poses.len();
+        let header = ARRAY_CONTAINER_TAG | len as u32;
+        // write header.
+        data.write_u32::<BigEndian>(header).unwrap();
+        let mut jentry_offset = data.len();
+        // reserve space for jentry.
+        data.resize(jentry_offset + 4 * len, 0);
+        while let Some(pos) = poses.pop_front() {
+            let jentry = match pos {
+                Position::Container((offset, length)) => {
+                    data.extend_from_slice(&root[offset..offset + length]);
+                    CONTAINER_TAG | length as u32
+                }
+                Position::Scalar((ty, offset, length)) => {
+                    if length > 0 {
+                        data.extend_from_slice(&root[offset..offset + length]);
+                    }
+                    ty | length as u32
+                }
+            };
+            for (i, b) in jentry.to_be_bytes().iter().enumerate() {
+                data[jentry_offset + i] = *b;
+            }
+            jentry_offset += 4;
+        }
+        offsets.push(data.len() as u64);
     }
 
     // check and convert index to Array index.
@@ -321,22 +398,22 @@ impl<'a> Selector<'a> {
         }
     }
 
-    fn filter_expr(&'a self, root: &'a [u8], current: &'a [u8], expr: &Expr<'a>) -> bool {
+    fn filter_expr(&'a self, root: &'a [u8], pos: &Position, expr: &Expr<'a>) -> bool {
         match expr {
             Expr::BinaryOp { op, left, right } => match op {
                 BinaryOperator::Or => {
-                    let lhs = self.filter_expr(root, current, left);
-                    let rhs = self.filter_expr(root, current, right);
+                    let lhs = self.filter_expr(root, pos, left);
+                    let rhs = self.filter_expr(root, pos, right);
                     lhs || rhs
                 }
                 BinaryOperator::And => {
-                    let lhs = self.filter_expr(root, current, left);
-                    let rhs = self.filter_expr(root, current, right);
+                    let lhs = self.filter_expr(root, pos, left);
+                    let rhs = self.filter_expr(root, pos, right);
                     lhs && rhs
                 }
                 _ => {
-                    let lhs = self.convert_expr_val(root, current, *left.clone());
-                    let rhs = self.convert_expr_val(root, current, *right.clone());
+                    let lhs = self.convert_expr_val(root, pos, *left.clone());
+                    let rhs = self.convert_expr_val(root, pos, *right.clone());
                     self.compare(op, &lhs, &rhs)
                 }
             },
@@ -344,38 +421,33 @@ impl<'a> Selector<'a> {
         }
     }
 
-    fn convert_expr_val(
-        &'a self,
-        root: &'a [u8],
-        current: &'a [u8],
-        expr: Expr<'a>,
-    ) -> ExprValue<'a> {
+    fn convert_expr_val(&'a self, root: &'a [u8], pos: &Position, expr: Expr<'a>) -> ExprValue<'a> {
         match expr {
             Expr::Value(value) => ExprValue::Value(value.clone()),
             Expr::Paths(paths) => {
                 // get value from path and convert to `ExprValue`.
-                let mut items = VecDeque::new();
+                let mut poses = VecDeque::new();
                 if let Some(Path::Current) = paths.get(0) {
-                    items.push_back(Item::Container(current));
+                    poses.push_back(pos.clone());
                 } else {
-                    items.push_back(Item::Container(root));
+                    poses.push_back(Position::Container((0, root.len())));
                 }
 
                 for path in paths.iter().skip(1) {
                     match path {
                         &Path::Root | &Path::Current | &Path::FilterExpr(_) => unreachable!(),
                         _ => {
-                            let len = items.len();
+                            let len = poses.len();
                             for _ in 0..len {
-                                let item = items.pop_front().unwrap();
-                                match item {
-                                    Item::Container(current) => {
-                                        self.select_path(current, path, &mut items);
+                                let pos = poses.pop_front().unwrap();
+                                match pos {
+                                    Position::Container((offset, length)) => {
+                                        self.select_path(root, offset, length, path, &mut poses);
                                     }
-                                    Item::Scalar(_) => {
+                                    Position::Scalar(_) => {
                                         // In lax mode, bracket wildcard allow Scalar value.
                                         if path == &Path::BracketWildcard {
-                                            items.push_back(item);
+                                            poses.push_back(pos);
                                         }
                                     }
                                 }
@@ -383,25 +455,19 @@ impl<'a> Selector<'a> {
                         }
                     }
                 }
-                let mut values = Vec::with_capacity(items.len());
-                while let Some(item) = items.pop_front() {
-                    let val = match item {
-                        Item::Container(val) => val,
-                        Item::Scalar(ref val) => val.as_slice(),
-                    };
-                    let (rest, (ty, _)) = decode_header(val).unwrap();
-                    if ty == SCALAR_CONTAINER_TAG {
-                        let (rest, (jty, jlength)) = decode_jentry(rest).unwrap();
-                        let value = match jty {
+                let mut values = Vec::with_capacity(poses.len());
+                while let Some(pos) = poses.pop_front() {
+                    if let Position::Scalar((ty, offset, length)) = pos {
+                        let value = match ty {
                             NULL_TAG => PathValue::Null,
                             TRUE_TAG => PathValue::Boolean(true),
                             FALSE_TAG => PathValue::Boolean(false),
                             NUMBER_TAG => {
-                                let n = Number::decode(&rest[0..jlength]);
+                                let n = Number::decode(&root[offset..offset + length]);
                                 PathValue::Number(n)
                             }
                             STRING_TAG => {
-                                let v = &rest[0..jlength];
+                                let v = &root[offset..offset + length];
                                 PathValue::String(Cow::Owned(unsafe {
                                     String::from_utf8_unchecked(v.to_vec())
                                 }))


### PR DESCRIPTION
improve json path selector using less memory

- The `Selector` records the `Position` of the value in the original value during the query process to avoid storing temporary data allocation memory.
- The result data is placed directly into the builder's buffer to avoid storing result data allocation memory.
