### PR TITLE
feat: added contains api

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -2025,10 +2025,6 @@ impl<'a> Iterator for ArrayIterator<'a> {
 
         Some(item)
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.length, Some(self.length))
-    }
 }
 
 struct ObjectKeyIterator<'a> {
@@ -2060,10 +2056,6 @@ impl<'a> Iterator for ObjectKeyIterator<'a> {
         self.jentry_offset += 4;
 
         Some(key)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.length, Some(self.length))
     }
 }
 
@@ -2107,10 +2099,6 @@ impl<'a> Iterator for ObjectEntryIterator<'a> {
             }
             None => None,
         }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.length, Some(self.length))
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::mem::discriminant;
 
 use super::number::Number;
 use super::ser::Encoder;
@@ -104,6 +105,10 @@ impl<'a> Display for Value<'a> {
 }
 
 impl<'a> Value<'a> {
+    pub fn is_scalar(&self) -> bool {
+        !self.is_array() && !self.is_object()
+    }
+
     pub fn is_object(&self) -> bool {
         self.as_object().is_some()
     }
@@ -251,5 +256,9 @@ impl<'a> Value<'a> {
             }
             _ => None,
         }
+    }
+
+    pub fn eq_variant(&self, other: &Value) -> bool {
+        discriminant(self) == discriminant(other)
     }
 }


### PR DESCRIPTION
Added `contains` function (supporting `@>` `<@` operators for https://github.com/datafuselabs/databend/issues/11270).

I've used implementation from postgres as reference. https://github.com/postgres/postgres/blob/23c8c0c8f4721db693ef908c22f7cf754e6852a9/src/backend/utils/adt/jsonb_util.c#L1064C9-L1064C9