### PR TITLE
feat: jsonpath predicate support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,7 @@ pub enum Error {
     InvalidJsonbJEntry,
 
     InvalidJsonPath,
+    InvalidJsonPathPredicate,
     InvalidKeyPath,
 
     Syntax(ParseErrorCode, usize),

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -163,6 +163,17 @@ pub fn path_exists<'a>(value: &'a [u8], json_path: JsonPath<'a>) -> bool {
     }
 }
 
+/// Returns the result of a JSON path predicate check for the specified `JSONB` value.
+pub fn path_match<'a>(value: &'a [u8], json_path: JsonPath<'a>) -> Result<bool, Error> {
+    let selector = Selector::new(json_path, Mode::First);
+    if !is_jsonb(value) {
+        let val = parse_value(value)?;
+        selector.predicate_match(&val.to_vec())
+    } else {
+        selector.predicate_match(value)
+    }
+}
+
 /// Get the inner elements of `JSONB` value by JSON path.
 /// The return value may contains multiple matching elements.
 pub fn get_by_path<'a>(

--- a/src/jsonpath/path.rs
+++ b/src/jsonpath/path.rs
@@ -25,6 +25,12 @@ pub struct JsonPath<'a> {
     pub paths: Vec<Path<'a>>,
 }
 
+impl<'a> JsonPath<'a> {
+    pub fn is_predicate(&self) -> bool {
+        self.paths.len() == 1 && matches!(self.paths[0], Path::Predicate(_))
+    }
+}
+
 /// Represents a valid JSON Path.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Path<'a> {
@@ -58,6 +64,8 @@ pub enum Path<'a> {
     ArrayIndices(Vec<ArrayIndex>),
     /// `?(<expression>)` represents selecting all elements in an object or array that match the filter expression, like `$.book[?(@.price < 10)]`.
     FilterExpr(Box<Expr<'a>>),
+    /// `<expression>` standalone filter expression, like `$.book[*].price > 10`.
+    Predicate(Box<Expr<'a>>),
 }
 
 /// Represents the single index in an Array.
@@ -209,6 +217,9 @@ impl<'a> Display for Path<'a> {
             }
             Path::FilterExpr(expr) => {
                 write!(f, "?({expr})")?;
+            }
+            Path::Predicate(expr) => {
+                write!(f, "{expr}")?;
             }
         }
         Ok(())

--- a/src/jsonpath/selector.rs
+++ b/src/jsonpath/selector.rs
@@ -28,6 +28,7 @@ use crate::jsonpath::JsonPath;
 use crate::jsonpath::Path;
 use crate::jsonpath::PathValue;
 use crate::number::Number;
+use crate::Error;
 
 use nom::{
     bytes::complete::take, combinator::map, multi::count, number::complete::be_u32, IResult,
@@ -74,6 +75,12 @@ impl<'a> Selector<'a> {
 
     pub fn select(&'a self, root: &'a [u8], data: &mut Vec<u8>, offsets: &mut Vec<u64>) {
         let mut poses = self.find_positions(root);
+
+        if self.json_path.is_predicate() {
+            Self::build_predicate_result(&mut poses, data);
+            return;
+        }
+
         match self.mode {
             Mode::All => Self::build_values(root, &mut poses, data, offsets),
             Mode::First => {
@@ -92,8 +99,19 @@ impl<'a> Selector<'a> {
     }
 
     pub fn exists(&'a self, root: &'a [u8]) -> bool {
+        if self.json_path.is_predicate() {
+            return true;
+        }
         let poses = self.find_positions(root);
         !poses.is_empty()
+    }
+
+    pub fn predicate_match(&'a self, root: &'a [u8]) -> Result<bool, Error> {
+        if !self.json_path.is_predicate() {
+            return Err(Error::InvalidJsonPathPredicate);
+        }
+        let poses = self.find_positions(root);
+        Ok(!poses.is_empty())
     }
 
     fn find_positions(&'a self, root: &'a [u8]) -> VecDeque<Position> {
@@ -106,7 +124,7 @@ impl<'a> Selector<'a> {
                     continue;
                 }
                 &Path::Current => unreachable!(),
-                Path::FilterExpr(expr) => {
+                Path::FilterExpr(expr) | Path::Predicate(expr) => {
                     let len = poses.len();
                     for _ in 0..len {
                         let pos = poses.pop_front().unwrap();
@@ -313,6 +331,15 @@ impl<'a> Selector<'a> {
         }
     }
 
+    fn build_predicate_result(poses: &mut VecDeque<Position>, data: &mut Vec<u8>) {
+        let jentry = match poses.pop_front() {
+            Some(_) => TRUE_TAG,
+            None => FALSE_TAG,
+        };
+        data.write_u32::<BigEndian>(SCALAR_CONTAINER_TAG).unwrap();
+        data.write_u32::<BigEndian>(jentry).unwrap();
+    }
+
     fn build_values(
         root: &'a [u8],
         poses: &mut VecDeque<Position>,
@@ -444,7 +471,7 @@ impl<'a> Selector<'a> {
 
                 for path in paths.iter().skip(1) {
                     match path {
-                        &Path::Root | &Path::Current | &Path::FilterExpr(_) => unreachable!(),
+                        &Path::Root | &Path::Current | &Path::FilterExpr(_) | &Path::Predicate(_) => unreachable!(),
                         _ => {
                             let len = poses.len();
                             for _ in 0..len {

--- a/src/jsonpath/selector.rs
+++ b/src/jsonpath/selector.rs
@@ -471,7 +471,10 @@ impl<'a> Selector<'a> {
 
                 for path in paths.iter().skip(1) {
                     match path {
-                        &Path::Root | &Path::Current | &Path::FilterExpr(_) | &Path::Predicate(_) => unreachable!(),
+                        &Path::Root
+                        | &Path::Current
+                        | &Path::FilterExpr(_)
+                        | &Path::Predicate(_) => unreachable!(),
                         _ => {
                             let len = poses.len();
                             for _ in 0..len {

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -155,16 +155,8 @@ fn test_path_exists() {
             true,
         ),
         // predicates always return true in path_exists.
-        (
-            r#"{"a":1,"b":[1,2,3]}"#,
-            r#"$.b[1 to last] > 10"#,
-            true,
-        ),
-        (
-            r#"{"a":1,"b":[1,2,3]}"#,
-            r#"$.b[1 to last] > 1"#,
-            true,
-        ),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[1 to last] > 10"#, true),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[1 to last] > 1"#, true),
     ];
     for (json, path, expect) in sources {
         // Check from JSONB
@@ -237,18 +229,9 @@ fn test_get_by_path() {
         (r#"$.car_no"#, vec![r#"123"#]),
         (r#"$.测试\"\uD83D\uDC8E"#, vec![r#""ab""#]),
         // predicates return the result of the filter expression.
-        (
-            r#"$.phones[0 to last].number == 3720453"#,
-            vec!["true"]
-        ),
-        (
-            r#"$.phones[0 to last].type == "workk""#,
-            vec!["false"]
-        ),
-        (
-            r#"$.name == "Fred" && $.car_no == 123"#,
-            vec!["true"]
-        ),
+        (r#"$.phones[0 to last].number == 3720453"#, vec!["true"]),
+        (r#"$.phones[0 to last].type == "workk""#, vec!["false"]),
+        (r#"$.name == "Fred" && $.car_no == 123"#, vec!["true"]),
     ];
 
     let mut buf: Vec<u8> = Vec::new();
@@ -1220,11 +1203,7 @@ fn test_path_match() {
         (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[0] == 1"#, true),
         (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[0] > 1"#, false),
         (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[3] == 0"#, false),
-        (
-            r#"{"a":1,"b":[1,2,3]}"#,
-            r#"$.b[1 to last] >= 2"#,
-            true,
-        ),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[1 to last] >= 2"#, true),
         (
             r#"{"a":1,"b":[1,2,3]}"#,
             r#"$.b[1 to last] == 2 || $.b[1 to last] == 3"#,

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -16,6 +16,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
+use jsonb::path_match;
 use jsonb::{
     array_length, array_values, as_bool, as_null, as_number, as_str, build_array, build_object,
     compare, contains, convert_to_comparable, exists_all_keys, exists_any_keys, from_slice,
@@ -153,6 +154,17 @@ fn test_path_exists() {
             r#"$.b[1 to last] ? (@ >=2 && @ <=3)"#,
             true,
         ),
+        // predicates always return true in path_exists.
+        (
+            r#"{"a":1,"b":[1,2,3]}"#,
+            r#"$.b[1 to last] > 10"#,
+            true,
+        ),
+        (
+            r#"{"a":1,"b":[1,2,3]}"#,
+            r#"$.b[1 to last] > 1"#,
+            true,
+        ),
     ];
     for (json, path, expect) in sources {
         // Check from JSONB
@@ -224,6 +236,19 @@ fn test_get_by_path() {
         ),
         (r#"$.car_no"#, vec![r#"123"#]),
         (r#"$.测试\"\uD83D\uDC8E"#, vec![r#""ab""#]),
+        // predicates return the result of the filter expression.
+        (
+            r#"$.phones[0 to last].number == 3720453"#,
+            vec!["true"]
+        ),
+        (
+            r#"$.phones[0 to last].type == "workk""#,
+            vec!["false"]
+        ),
+        (
+            r#"$.name == "Fred" && $.car_no == 123"#,
+            vec!["true"]
+        ),
     ];
 
     let mut buf: Vec<u8> = Vec::new();
@@ -1180,6 +1205,41 @@ fn test_contains() {
         }
         {
             let result = contains(left.as_bytes(), right.as_bytes());
+            assert_eq!(result, expected);
+        }
+    }
+}
+
+#[test]
+fn test_path_match() {
+    let sources = vec![
+        (r#"{"a":1,"b":2}"#, r#"$.a == 1"#, true),
+        (r#"{"a":1,"b":2}"#, r#"$.a > 1"#, false),
+        (r#"{"a":1,"b":2}"#, r#"$.c > 0"#, false),
+        (r#"{"a":1,"b":2}"#, r#"$.b < 2"#, false),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[0] == 1"#, true),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[0] > 1"#, false),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"$.b[3] == 0"#, false),
+        (
+            r#"{"a":1,"b":[1,2,3]}"#,
+            r#"$.b[1 to last] >= 2"#,
+            true,
+        ),
+        (
+            r#"{"a":1,"b":[1,2,3]}"#,
+            r#"$.b[1 to last] == 2 || $.b[1 to last] == 3"#,
+            true,
+        ),
+    ];
+    for (json, predicate, expected) in sources {
+        let json_path = parse_json_path(predicate.as_bytes()).unwrap();
+        {
+            let result = path_match(json.as_bytes(), json_path.clone()).unwrap();
+            assert_eq!(result, expected);
+        }
+        {
+            let json = parse_value(json.as_bytes()).unwrap().to_vec();
+            let result = path_match(&json, json_path).unwrap();
             assert_eq!(result, expected);
         }
     }

--- a/tests/it/jsonpath_parser.rs
+++ b/tests/it/jsonpath_parser.rs
@@ -44,6 +44,12 @@ fn test_json_path() {
         r#"["k1"]["k2"]"#,
         r#"k1.k2:k3"#,
         r#"k1["k2"][1]"#,
+        // predicates
+        r#"$ > 1"#,
+        r#"$.* == 0"#,
+        r#"$[*] > 1"#,
+        r#"$.a > $.b"#,
+        r#"$.price > 10 || $.category == "reference""#,
     ];
 
     for case in cases {
@@ -74,6 +80,7 @@ fn test_json_path_error() {
         r#"$['1','2',]"#,
         r#"$['1', ,'3']"#,
         r#"$['aaa'}'bbb']"#,
+        r#"@ > 10"#,
     ];
 
     for case in cases {

--- a/tests/it/testdata/json_path.txt
+++ b/tests/it/testdata/json_path.txt
@@ -660,3 +660,171 @@ JsonPath {
 }
 
 
+---------- Input ----------
+$ > 1
+---------- Output ---------
+$ > 1
+---------- AST ------------
+JsonPath {
+    paths: [
+        Predicate(
+            BinaryOp {
+                op: Gt,
+                left: Paths(
+                    [
+                        Root,
+                    ],
+                ),
+                right: Value(
+                    Number(
+                        UInt64(
+                            1,
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
+
+---------- Input ----------
+$.* == 0
+---------- Output ---------
+$.* == 0
+---------- AST ------------
+JsonPath {
+    paths: [
+        Predicate(
+            BinaryOp {
+                op: Eq,
+                left: Paths(
+                    [
+                        Root,
+                        DotWildcard,
+                    ],
+                ),
+                right: Value(
+                    Number(
+                        UInt64(
+                            0,
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
+
+---------- Input ----------
+$[*] > 1
+---------- Output ---------
+$[*] > 1
+---------- AST ------------
+JsonPath {
+    paths: [
+        Predicate(
+            BinaryOp {
+                op: Gt,
+                left: Paths(
+                    [
+                        Root,
+                        BracketWildcard,
+                    ],
+                ),
+                right: Value(
+                    Number(
+                        UInt64(
+                            1,
+                        ),
+                    ),
+                ),
+            },
+        ),
+    ],
+}
+
+
+---------- Input ----------
+$.a > $.b
+---------- Output ---------
+$.a > $.b
+---------- AST ------------
+JsonPath {
+    paths: [
+        Predicate(
+            BinaryOp {
+                op: Gt,
+                left: Paths(
+                    [
+                        Root,
+                        DotField(
+                            "a",
+                        ),
+                    ],
+                ),
+                right: Paths(
+                    [
+                        Root,
+                        DotField(
+                            "b",
+                        ),
+                    ],
+                ),
+            },
+        ),
+    ],
+}
+
+
+---------- Input ----------
+$.price > 10 || $.category == "reference"
+---------- Output ---------
+$.price > 10 || $.category == "reference"
+---------- AST ------------
+JsonPath {
+    paths: [
+        Predicate(
+            BinaryOp {
+                op: Or,
+                left: BinaryOp {
+                    op: Gt,
+                    left: Paths(
+                        [
+                            Root,
+                            DotField(
+                                "price",
+                            ),
+                        ],
+                    ),
+                    right: Value(
+                        Number(
+                            UInt64(
+                                10,
+                            ),
+                        ),
+                    ),
+                },
+                right: BinaryOp {
+                    op: Eq,
+                    left: Paths(
+                        [
+                            Root,
+                            DotField(
+                                "category",
+                            ),
+                        ],
+                    ),
+                    right: Value(
+                        String(
+                            "reference",
+                        ),
+                    ),
+                },
+            },
+        ),
+    ],
+}
+
+


### PR DESCRIPTION
1. Added support of jsonpath predicates;
2. Added `path_match` function (supporting `@@` and `json_path_match` for https://github.com/datafuselabs/databend/issues/11270);


Here I've tried to achieve the same behaviour of predicates like postgres has:
1. Selecting the result of the predicate path from json should return the predicate result itself, so `Selector::select` returns `true` or `false` in jsonb format;
2. `json_path_exists` always returns `true` on predicates, because  selector always has the result on it (`true` or `false`)
3. `@` is forbidden in predicate expression;

I've found the good explanation here https://justatheory.com/2023/10/sql-jsonpath-operators/
