### PR TITLE
feat: add concat & improve strip_nulls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,6 @@ harness = false
 name = "get_path"
 harness = false
 
+[[bench]]
+name = "strip_nulls"
+harness = false

--- a/benches/strip_nulls.rs
+++ b/benches/strip_nulls.rs
@@ -29,7 +29,7 @@ fn strip_nulls_deser(data: &[u8]) {
     let mut json = from_slice(data).unwrap();
     strip_value_nulls(&mut json);
     json.write_to_vec(&mut buf);
-    assert_eq!(buf.is_empty(), false);
+    assert!(!buf.is_empty());
 }
 
 fn strip_value_nulls(val: &mut Value<'_>) {
@@ -52,7 +52,7 @@ fn strip_value_nulls(val: &mut Value<'_>) {
 fn strip_nulls_fast(data: &[u8]) {
     let mut buf = Vec::new();
     strip_nulls(data, &mut buf).unwrap();
-    assert_eq!(buf.is_empty(), false);
+    assert!(!buf.is_empty());
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/benches/strip_nulls.rs
+++ b/benches/strip_nulls.rs
@@ -1,0 +1,76 @@
+// Copyright 2024 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fs, io::Read};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use jsonb::{from_slice, strip_nulls, Value};
+
+fn read(file: &str) -> Vec<u8> {
+    let mut f = fs::File::open(file).unwrap();
+    let mut data = vec![];
+    f.read_to_end(&mut data).unwrap();
+    data
+}
+
+fn strip_nulls_deser(data: &[u8]) {
+    let mut buf = Vec::new();
+    let mut json = from_slice(data).unwrap();
+    strip_value_nulls(&mut json);
+    json.write_to_vec(&mut buf);
+    assert_eq!(buf.is_empty(), false);
+}
+
+fn strip_value_nulls(val: &mut Value<'_>) {
+    match val {
+        Value::Array(arr) => {
+            for v in arr {
+                strip_value_nulls(v);
+            }
+        }
+        Value::Object(ref mut obj) => {
+            for (_, v) in obj.iter_mut() {
+                strip_value_nulls(v);
+            }
+            obj.retain(|_, v| !matches!(v, Value::Null));
+        }
+        _ => {}
+    }
+}
+
+fn strip_nulls_fast(data: &[u8]) {
+    let mut buf = Vec::new();
+    strip_nulls(data, &mut buf).unwrap();
+    assert_eq!(buf.is_empty(), false);
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let paths = fs::read_dir("./data/").unwrap();
+    for path in paths {
+        let file = format!("{}", path.unwrap().path().display());
+        let bytes = read(&file);
+        let json = from_slice(&bytes).unwrap().to_vec();
+
+        c.bench_function(&format!("strip_nulls_deser[{}]", file), |b| {
+            b.iter(|| strip_nulls_deser(&json));
+        });
+
+        c.bench_function(&format!("strip_nulls_fast[{}]", file), |b| {
+            b.iter(|| strip_nulls_fast(&json));
+        });
+    }
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,149 @@
+// Copyright 2024 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use byteorder::{BigEndian, WriteBytesExt};
+
+use crate::{
+    constants::{ARRAY_CONTAINER_TAG, OBJECT_CONTAINER_TAG},
+    jentry::JEntry,
+};
+
+enum Entry<'a> {
+    ArrayBuilder(ArrayBuilder<'a>),
+    ObjectBuilder(ObjectBuilder<'a>),
+    Raw(JEntry, &'a [u8]),
+}
+
+pub(crate) struct ArrayBuilder<'a> {
+    entries: Vec<Entry<'a>>,
+}
+
+impl<'a> ArrayBuilder<'a> {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            entries: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub(crate) fn push_raw(&mut self, jentry: JEntry, data: &'a [u8]) {
+        self.entries.push(Entry::Raw(jentry, data));
+    }
+
+    pub(crate) fn push_array(&mut self, builder: ArrayBuilder<'a>) {
+        self.entries.push(Entry::ArrayBuilder(builder));
+    }
+
+    pub(crate) fn push_object(&mut self, builder: ObjectBuilder<'a>) {
+        self.entries.push(Entry::ObjectBuilder(builder));
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn build_into(self, buf: &mut Vec<u8>) {
+        let header = ARRAY_CONTAINER_TAG | self.entries.len() as u32;
+        buf.write_u32::<BigEndian>(header).unwrap();
+
+        let mut jentry_index = reserve_jentries(buf, self.entries.len() * 4);
+
+        for entry in self.entries.into_iter() {
+            let jentry = write_entry(buf, entry);
+            replace_jentry(buf, jentry, &mut jentry_index);
+        }
+    }
+}
+
+pub(crate) struct ObjectBuilder<'a> {
+    entries: BTreeMap<&'a str, Entry<'a>>,
+}
+
+impl<'a> ObjectBuilder<'a> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn push_raw(&mut self, key: &'a str, jentry: JEntry, data: &'a [u8]) {
+        self.entries.insert(key, Entry::Raw(jentry, data));
+    }
+
+    pub(crate) fn push_array(&mut self, key: &'a str, builder: ArrayBuilder<'a>) {
+        self.entries.insert(key, Entry::ArrayBuilder(builder));
+    }
+
+    pub(crate) fn push_object(&mut self, key: &'a str, builder: ObjectBuilder<'a>) {
+        self.entries.insert(key, Entry::ObjectBuilder(builder));
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn build_into(self, buf: &mut Vec<u8>) {
+        let header = OBJECT_CONTAINER_TAG | self.entries.len() as u32;
+        buf.write_u32::<BigEndian>(header).unwrap();
+
+        let mut jentry_index = reserve_jentries(buf, self.entries.len() * 8);
+
+        for (key, _) in self.entries.iter() {
+            let key_len = key.len();
+            buf.extend_from_slice(key.as_bytes());
+            let jentry = JEntry::make_string_jentry(key_len);
+            replace_jentry(buf, jentry, &mut jentry_index)
+        }
+
+        for (_, entry) in self.entries.into_iter() {
+            let jentry = write_entry(buf, entry);
+            replace_jentry(buf, jentry, &mut jentry_index);
+        }
+    }
+}
+
+fn write_entry(buf: &mut Vec<u8>, entry: Entry<'_>) -> JEntry {
+    match entry {
+        Entry::ArrayBuilder(builder) => {
+            let jentry = JEntry::make_container_jentry(builder.len());
+            builder.build_into(buf);
+            jentry
+        }
+        Entry::ObjectBuilder(builder) => {
+            let jentry = JEntry::make_container_jentry(builder.len());
+            builder.build_into(buf);
+            jentry
+        }
+        Entry::Raw(jentry, data) => {
+            buf.extend_from_slice(data);
+            jentry
+        }
+    }
+}
+
+fn reserve_jentries(buf: &mut Vec<u8>, len: usize) -> usize {
+    let old_len = buf.len();
+    let new_len = old_len + len;
+    buf.resize(new_len, 0);
+    old_len
+}
+
+fn replace_jentry(buf: &mut [u8], jentry: JEntry, jentry_index: &mut usize) {
+    let jentry_bytes = jentry.encoded().to_be_bytes();
+    for (i, b) in jentry_bytes.iter().enumerate() {
+        buf[*jentry_index + i] = *b;
+    }
+    *jentry_index += 4;
+}

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,0 +1,182 @@
+// Copyright 2024 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::VecDeque, str::from_utf8_unchecked};
+
+use crate::{constants::CONTAINER_HEADER_LEN_MASK, jentry::JEntry, Error};
+
+pub(crate) fn iterate_array(value: &[u8], header: u32) -> ArrayIterator<'_> {
+    let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+    ArrayIterator {
+        value,
+        jentry_offset: 4,
+        val_offset: 4 * length + 4,
+        length,
+        idx: 0,
+    }
+}
+
+pub(crate) fn iteate_object_keys(value: &[u8], header: u32) -> ObjectKeyIterator<'_> {
+    let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+    ObjectKeyIterator {
+        value,
+        jentry_offset: 4,
+        key_offset: 8 * length + 4,
+        length,
+        idx: 0,
+    }
+}
+
+pub(crate) fn iterate_object_entries(value: &[u8], header: u32) -> ObjectEntryIterator<'_> {
+    let length = (header & CONTAINER_HEADER_LEN_MASK) as usize;
+    ObjectEntryIterator {
+        value,
+        jentry_offset: 4,
+        key_offset: 4 + length * 8,
+        val_offset: 4 + length * 8,
+        length,
+        keys: None,
+    }
+}
+
+pub(crate) struct ArrayIterator<'a> {
+    value: &'a [u8],
+    jentry_offset: usize,
+    val_offset: usize,
+    length: usize,
+    idx: usize,
+}
+
+impl<'a> Iterator for ArrayIterator<'a> {
+    type Item = (JEntry, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.length {
+            return None;
+        }
+        let encoded = read_u32(self.value, self.jentry_offset).unwrap();
+        let jentry = JEntry::decode_jentry(encoded);
+        let val_length = jentry.length as usize;
+
+        let item = (
+            jentry,
+            &self.value[self.val_offset..self.val_offset + val_length],
+        );
+
+        self.idx += 1;
+        self.val_offset += val_length;
+        self.jentry_offset += 4;
+
+        Some(item)
+    }
+}
+
+pub(crate) struct ObjectKeyIterator<'a> {
+    value: &'a [u8],
+    jentry_offset: usize,
+    key_offset: usize,
+    length: usize,
+    idx: usize,
+}
+
+impl<'a> Iterator for ObjectKeyIterator<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.length {
+            return None;
+        }
+
+        let encoded = read_u32(self.value, self.jentry_offset).unwrap();
+        let jentry = JEntry::decode_jentry(encoded);
+        let key_length = jentry.length as usize;
+
+        let key = unsafe {
+            from_utf8_unchecked(&self.value[self.key_offset..self.key_offset + key_length])
+        };
+
+        self.idx += 1;
+        self.key_offset += key_length;
+        self.jentry_offset += 4;
+
+        Some(key)
+    }
+}
+
+pub(crate) struct ObjectEntryIterator<'a> {
+    value: &'a [u8],
+    jentry_offset: usize,
+    key_offset: usize,
+    val_offset: usize,
+    length: usize,
+    keys: Option<VecDeque<JEntry>>,
+}
+
+impl<'a> Iterator for ObjectEntryIterator<'a> {
+    type Item = (&'a str, JEntry, &'a [u8]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.keys.is_none() {
+            self.fill_keys();
+        }
+        match self.keys.as_mut().unwrap().pop_front() {
+            Some(key_jentry) => {
+                let prev_key_offset = self.key_offset;
+                self.key_offset += key_jentry.length as usize;
+
+                let key = unsafe {
+                    std::str::from_utf8_unchecked(&self.value[prev_key_offset..self.key_offset])
+                };
+
+                let val_encoded = read_u32(self.value, self.jentry_offset).unwrap();
+                let val_jentry = JEntry::decode_jentry(val_encoded);
+                let val_length = val_jentry.length as usize;
+
+                let val =
+                    &self.value[self.val_offset..self.val_offset + val_jentry.length as usize];
+                let result = (key, val_jentry, val);
+
+                self.jentry_offset += 4;
+                self.val_offset += val_length;
+
+                Some(result)
+            }
+            None => None,
+        }
+    }
+}
+
+impl<'a> ObjectEntryIterator<'a> {
+    fn fill_keys(&mut self) {
+        let mut keys: VecDeque<JEntry> = VecDeque::with_capacity(self.length);
+        for _ in 0..self.length {
+            let encoded = read_u32(self.value, self.jentry_offset).unwrap();
+            let key_jentry = JEntry::decode_jentry(encoded);
+
+            self.jentry_offset += 4;
+            self.val_offset += key_jentry.length as usize;
+            keys.push_back(key_jentry);
+        }
+        self.keys = Some(keys);
+    }
+}
+
+fn read_u32(buf: &[u8], idx: usize) -> Result<u32, Error> {
+    let bytes: [u8; 4] = buf
+        .get(idx..idx + 4)
+        .ok_or(Error::InvalidEOF)?
+        .try_into()
+        .unwrap();
+    Ok(u32::from_be_bytes(bytes))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,13 @@
 
 #![allow(clippy::uninlined_format_args)]
 
+mod builder;
 mod constants;
 mod de;
 mod error;
 mod from;
 mod functions;
+mod iterator;
 mod jentry;
 pub mod jsonpath;
 pub mod keypath;

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -18,13 +18,12 @@ use std::collections::BTreeMap;
 
 use jsonb::{
     array_length, array_values, as_bool, as_null, as_number, as_str, build_array, build_object,
-    compare, contains, convert_to_comparable, exists_all_keys, exists_any_keys, from_slice,
+    compare, concat, contains, convert_to_comparable, exists_all_keys, exists_any_keys, from_slice,
     get_by_index, get_by_keypath, get_by_name, get_by_path, is_array, is_object,
-    keypath::parse_key_paths, object_each, object_keys, parse_value, path_exists, strip_nulls,
-    to_bool, to_f64, to_i64, to_pretty_string, to_str, to_string, to_u64, traverse_check_string,
-    type_of, Number, Object, Value,
+    keypath::parse_key_paths, object_each, object_keys, parse_value, path_exists, path_match,
+    strip_nulls, to_bool, to_f64, to_i64, to_pretty_string, to_str, to_string, to_u64,
+    traverse_check_string, type_of, Number, Object, Value,
 };
-use jsonb::{concat, path_match};
 
 use jsonb::jsonpath::parse_json_path;
 use nom::AsBytes;


### PR DESCRIPTION
1. Added a builder api, which allows a json modification without the full deserialisation;
2. Added `concat` for https://github.com/datafuselabs/databend/issues/11270;
3. Moved `strip_nulls` to the new builder;

Also, added a benchmark for comparing the `strip_nulls` implementations.

Results for m1 pro are:
```
strip_nulls_deser[./data/canada.json]
                        time:   [5.5970 ms 5.6163 ms 5.6352 ms]

strip_nulls_fast[./data/canada.json]
                        time:   [2.8134 ms 2.8249 ms 2.8363 ms]

Benchmarking strip_nulls_deser[./data/twitter.json]: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
strip_nulls_deser[./data/twitter.json]
                        time:   [1.7488 ms 1.7705 ms 1.8024 ms]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

strip_nulls_fast[./data/twitter.json]
                        time:   [812.35 µs 815.72 µs 819.60 µs]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

strip_nulls_deser[./data/citm_catalog.json]
                        time:   [4.4845 ms 4.5077 ms 4.5306 ms]

strip_nulls_fast[./data/citm_catalog.json]
                        time:   [2.6602 ms 2.6698 ms 2.6797 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```