### PR TITLE
fix: builder&concat container jentry len fix

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1957,7 +1957,7 @@ fn concat_jsonb(left: &[u8], right: &[u8], buf: &mut Vec<u8>) -> Result<(), Erro
             let mut builder = ArrayBuilder::new(right_len + 1);
             match left_type {
                 OBJECT_CONTAINER_TAG => {
-                    let jentry = JEntry::make_container_jentry(left_len);
+                    let jentry = JEntry::make_container_jentry(left.len());
                     builder.push_raw(jentry, left);
                 }
                 _ => {
@@ -1977,7 +1977,7 @@ fn concat_jsonb(left: &[u8], right: &[u8], buf: &mut Vec<u8>) -> Result<(), Erro
             }
             match right_type {
                 OBJECT_CONTAINER_TAG => {
-                    let jentry = JEntry::make_container_jentry(right_len);
+                    let jentry = JEntry::make_container_jentry(right.len());
                     builder.push_raw(jentry, right);
                 }
                 _ => {
@@ -1991,7 +1991,7 @@ fn concat_jsonb(left: &[u8], right: &[u8], buf: &mut Vec<u8>) -> Result<(), Erro
             let mut builder = ArrayBuilder::new(2);
             match left_type {
                 OBJECT_CONTAINER_TAG => {
-                    let jentry = JEntry::make_container_jentry(left_len);
+                    let jentry = JEntry::make_container_jentry(left.len());
                     builder.push_raw(jentry, left);
                 }
                 _ => {
@@ -2001,7 +2001,7 @@ fn concat_jsonb(left: &[u8], right: &[u8], buf: &mut Vec<u8>) -> Result<(), Erro
             };
             match right_type {
                 OBJECT_CONTAINER_TAG => {
-                    let jentry = JEntry::make_container_jentry(right_len);
+                    let jentry = JEntry::make_container_jentry(right.len());
                     builder.push_raw(jentry, right);
                 }
                 _ => {

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -1247,6 +1247,8 @@ fn test_concat() {
             r#"[1,[1,2,3],3,[10,20,30]]"#,
         ),
         (r#"{"a":1,"b":2}"#, r#"true"#, r#"[{"a":1,"b":2},true]"#),
+        (r#"{"a":1,"b":2}"#, r#"123"#, r#"[{"a":1,"b":2},123]"#),
+        (r#"{"a":1,"b":2}"#, r#""asd""#, r#"[{"a":1,"b":2},"asd"]"#),
         (r#"[1,2,3]"#, r#"{"a":1,"b":2}"#, r#"[1,2,3,{"a":1,"b":2}]"#),
         (r#"{"a":1,"b":2}"#, r#"[1,2,3]"#, r#"[{"a":1,"b":2},1,2,3]"#),
         (
@@ -1268,7 +1270,9 @@ fn test_concat() {
 
             let actual = from_slice(&buf).unwrap();
             let expected = parse_value(result.as_bytes()).unwrap();
+
             assert_eq!(actual, expected);
+            assert_eq!(to_string(&buf), result);
         }
         {
             let mut buf = Vec::new();
@@ -1279,7 +1283,9 @@ fn test_concat() {
 
             let actual = from_slice(&buf).unwrap();
             let expected = parse_value(result.as_bytes()).unwrap();
+
             assert_eq!(actual, expected);
+            assert_eq!(to_string(&buf), result);
         }
     }
 }


### PR DESCRIPTION
Fix `jentry` length encoding for containers in `concat` and `builder`.

Discovered while testing in databend. Seems that the encoded len in the container `jentry` is not using in serde. So the previous tests were green :)