### PR TITLE
feat: add delete_by_index & delete_by_name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -83,6 +83,8 @@ pub enum Error {
     InvalidJsonPathPredicate,
     InvalidKeyPath,
 
+    InvalidJsonType,
+
     Syntax(ParseErrorCode, usize),
 }
 

--- a/src/jsonpath/selector.rs
+++ b/src/jsonpath/selector.rs
@@ -463,7 +463,7 @@ impl<'a> Selector<'a> {
             Expr::Paths(paths) => {
                 // get value from path and convert to `ExprValue`.
                 let mut poses = VecDeque::new();
-                if let Some(Path::Current) = paths.get(0) {
+                if let Some(Path::Current) = paths.first() {
                     poses.push_back(pos.clone());
                 } else {
                     poses.push_back(Position::Container((0, root.len())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ mod value;
 
 pub use de::from_slice;
 pub use error::Error;
+#[allow(unused_imports)]
 pub use from::*;
 pub use functions::*;
 pub use number::Number;

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -1338,7 +1338,7 @@ fn test_delete_by_name_errors() {
             let result = delete_by_name(json.as_bytes(), name, &mut buf);
 
             assert!(result.is_err());
-            matches!(result.unwrap_err(), Error::InvalidJsonType);
+            assert!(matches!(result.unwrap_err(), Error::InvalidJsonType));
         }
         {
             let json = parse_value(json.as_bytes()).unwrap().to_vec();
@@ -1347,7 +1347,7 @@ fn test_delete_by_name_errors() {
             let result = delete_by_name(&json, name, &mut buf);
 
             assert!(result.is_err());
-            matches!(result.unwrap_err(), Error::InvalidJsonType);
+            assert!(matches!(result.unwrap_err(), Error::InvalidJsonType));
         }
     }
 }
@@ -1402,7 +1402,7 @@ fn test_delete_by_index_errors() {
             let result = delete_by_index(json.as_bytes(), index, &mut buf);
 
             assert!(result.is_err());
-            matches!(result.unwrap_err(), Error::InvalidJsonType);
+            assert!(matches!(result.unwrap_err(), Error::InvalidJsonType));
         }
         {
             let json = parse_value(json.as_bytes()).unwrap().to_vec();
@@ -1411,7 +1411,7 @@ fn test_delete_by_index_errors() {
             let result = delete_by_index(&json, index, &mut buf);
 
             assert!(result.is_err());
-            matches!(result.unwrap_err(), Error::InvalidJsonType);
+            assert!(matches!(result.unwrap_err(), Error::InvalidJsonType));
         }
     }
 }


### PR DESCRIPTION
Added `delete_by_index` and `delete_by_name` (supporting delete operators for https://github.com/datafuselabs/databend/issues/11270) 