### PR TITLE
fix: fix jsonpath selector unwrap panic

### DIFF
--- a/benches/get_path.rs
+++ b/benches/get_path.rs
@@ -27,7 +27,7 @@ fn jsonb_get(data: &[u8], paths: &[&str], expected: &str) {
     let mut result_data = vec![];
     let mut result_offsets = vec![];
 
-    jsonb::get_by_path(data, json_path, &mut result_data, &mut result_offsets);
+    jsonb::get_by_path(data, json_path, &mut result_data, &mut result_offsets).unwrap();
 
     let s = jsonb::as_str(&result_data).unwrap();
     assert_eq!(s, expected);

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,3 +109,9 @@ impl From<std::str::Utf8Error> for Error {
         Error::InvalidUtf8
     }
 }
+
+impl From<nom::Err<nom::error::Error<&[u8]>>> for Error {
+    fn from(_error: nom::Err<nom::error::Error<&[u8]>>) -> Self {
+        Error::InvalidJsonb
+    }
+}

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -155,7 +155,7 @@ pub fn array_length(value: &[u8]) -> Option<usize> {
 }
 
 /// Checks whether the JSON path returns any item for the `JSONB` value.
-pub fn path_exists<'a>(value: &'a [u8], json_path: JsonPath<'a>) -> bool {
+pub fn path_exists<'a>(value: &'a [u8], json_path: JsonPath<'a>) -> Result<bool, Error> {
     let selector = Selector::new(json_path, Mode::Mixed);
     if !is_jsonb(value) {
         match parse_value(value) {
@@ -163,7 +163,7 @@ pub fn path_exists<'a>(value: &'a [u8], json_path: JsonPath<'a>) -> bool {
                 let value = val.to_vec();
                 selector.exists(value.as_slice())
             }
-            Err(_) => false,
+            Err(_) => Ok(false),
         }
     } else {
         selector.exists(value)
@@ -188,16 +188,17 @@ pub fn get_by_path<'a>(
     json_path: JsonPath<'a>,
     data: &mut Vec<u8>,
     offsets: &mut Vec<u64>,
-) {
+) -> Result<(), Error> {
     let selector = Selector::new(json_path, Mode::Mixed);
     if !is_jsonb(value) {
         if let Ok(val) = parse_value(value) {
             let value = val.to_vec();
-            selector.select(value.as_slice(), data, offsets)
+            selector.select(value.as_slice(), data, offsets)?;
         }
     } else {
-        selector.select(value, data, offsets)
+        selector.select(value, data, offsets)?;
     }
+    Ok(())
 }
 
 /// Get the inner element of `JSONB` value by JSON path.
@@ -207,16 +208,17 @@ pub fn get_by_path_first<'a>(
     json_path: JsonPath<'a>,
     data: &mut Vec<u8>,
     offsets: &mut Vec<u64>,
-) {
+) -> Result<(), Error> {
     let selector = Selector::new(json_path, Mode::First);
     if !is_jsonb(value) {
         if let Ok(val) = parse_value(value) {
             let value = val.to_vec();
-            selector.select(value.as_slice(), data, offsets)
+            selector.select(value.as_slice(), data, offsets)?;
         }
     } else {
-        selector.select(value, data, offsets)
+        selector.select(value, data, offsets)?;
     }
+    Ok(())
 }
 
 /// Get the inner elements of `JSONB` value by JSON path.
@@ -226,16 +228,17 @@ pub fn get_by_path_array<'a>(
     json_path: JsonPath<'a>,
     data: &mut Vec<u8>,
     offsets: &mut Vec<u64>,
-) {
+) -> Result<(), Error> {
     let selector = Selector::new(json_path, Mode::Array);
     if !is_jsonb(value) {
         if let Ok(val) = parse_value(value) {
             let value = val.to_vec();
-            selector.select(value.as_slice(), data, offsets)
+            selector.select(value.as_slice(), data, offsets)?;
         }
     } else {
-        selector.select(value, data, offsets)
+        selector.select(value, data, offsets)?;
     }
+    Ok(())
 }
 
 /// Get the inner element of `JSONB` Array by index.

--- a/tests/it/functions.rs
+++ b/tests/it/functions.rs
@@ -164,13 +164,13 @@ fn test_path_exists() {
             let value = parse_value(json.as_bytes()).unwrap().to_vec();
             let json_path = parse_json_path(path.as_bytes()).unwrap();
             let res = path_exists(value.as_slice(), json_path);
-            assert_eq!(res, expect);
+            assert_eq!(res, Ok(expect));
         }
         // Check from String JSON
         {
             let json_path = parse_json_path(path.as_bytes()).unwrap();
             let res = path_exists(json.as_bytes(), json_path);
-            assert_eq!(res, expect);
+            assert_eq!(res, Ok(expect));
         }
     }
 }
@@ -236,7 +236,8 @@ fn test_path_exists_expr() {
         let mut out_offsets: Vec<u64> = Vec::new();
         let json_path = parse_json_path(path.as_bytes()).unwrap();
 
-        get_by_path_array(&buf, json_path, &mut out_buf, &mut out_offsets);
+        let res = get_by_path_array(&buf, json_path, &mut out_buf, &mut out_offsets);
+        assert!(res.is_ok());
         let expected_buf = parse_value(expected.as_bytes()).unwrap().to_vec();
 
         assert_eq!(out_buf, expected_buf);
@@ -311,7 +312,8 @@ fn test_get_by_path() {
         out_buf.clear();
         out_offsets.clear();
         let json_path = parse_json_path(path.as_bytes()).unwrap();
-        get_by_path(&buf, json_path, &mut out_buf, &mut out_offsets);
+        let res = get_by_path(&buf, json_path, &mut out_buf, &mut out_offsets);
+        assert!(res.is_ok());
         if expects.is_empty() {
             assert_eq!(out_offsets.len(), expects.len());
         } else if expects.len() == 1 {


### PR DESCRIPTION
jsonpath selector functions return `Result` instead of using `unwrap` function, prevents panic caused by handing invalid jsonb data

